### PR TITLE
Fix bug with grow/shrink and wrong layout in the ZeroAwareAllocator

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,6 +18,17 @@ jobs:
     - run: rustup component add rustfmt
     - run: cargo fmt --all --check
 
+  fuzz:
+    runs-on: ubtuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - run: rustup toolchain install nightly
+    - run: rustup default nightly
+    - run: cargo install cargo-fuzz
+    - run: cargo fuzz build ops --sanitizer none
+    # Smoke test: run the fuzzer for 3 minutes.
+    - run: cargo fuzz run ops --sanitizer none -- -timeout=180
+
   build:
     runs-on: ubuntu-latest
     strategy:
@@ -39,14 +50,3 @@ jobs:
     - run: rustup toolchain install ${{ matrix.rust_channel }}
     - run: rustup default ${{ matrix.rust_channel }}
     - run: cargo test --verbose ${{ matrix.features }}
-
-  fuzz:
-    runs-on: ubtuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-    - run: rustup toolchain install nightly
-    - run: rustup default nightly
-    - run: cargo install cargo-fuzz
-    - run: cargo fuzz build ops --sanitizer none
-    # Smoke test: run the fuzzer for 3 minutes.
-    - run: cargo fuzz run ops --sanitizer none -- -timeout=180

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,6 +17,7 @@ jobs:
     - run: rustup update
     - run: rustup component add rustfmt
     - run: cargo fmt --all --check
+
   build:
     runs-on: ubuntu-latest
     strategy:
@@ -38,3 +39,14 @@ jobs:
     - run: rustup toolchain install ${{ matrix.rust_channel }}
     - run: rustup default ${{ matrix.rust_channel }}
     - run: cargo test --verbose ${{ matrix.features }}
+
+  fuzz:
+    runs-on: ubtuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - run: rustup toolchain install nightly
+    - run: rustup default nightly
+    - run: cargo install cargo-fuzz
+    - run: cargo fuzz build ops --sanitizer none
+    # Smoke test: run the fuzzer for 3 minutes.
+    - run: cargo fuzz run ops --sanitizer none -- -timeout=180

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,14 @@
 members = [
   ".",
   "crates/fuzzing",
+  "fuzz",
 ]
+
+[workspace.dependencies]
+bincode = "2.0.1"
+env_logger = "0.11.6"
+log = "0.4.22"
+mutatis = { version = "0.3.1", features = ["check", "derive"] }
 
 [package]
 authors = ["Nick Fitzgerald <fitzgen@gmail.com>"]

--- a/crates/fuzzing/Cargo.toml
+++ b/crates/fuzzing/Cargo.toml
@@ -5,9 +5,10 @@ edition = "2021"
 publish = false
 
 [dependencies]
+bincode = { workspace = true }
 deallocate-zeroed = { path = "../..", features = ["allocator_api", "zero_aware_allocator"] }
-log = "0.4.22"
-mutatis = { version = "0.3.1", features = ["check", "derive"] }
+log = { workspace = true }
+mutatis = { workspace = true }
 
 [dev-dependencies]
-env_logger = "0.11.6"
+env_logger = { workspace = true }

--- a/crates/fuzzing/src/lib.rs
+++ b/crates/fuzzing/src/lib.rs
@@ -49,7 +49,10 @@ impl Layout {
     }
 
     fn align(&self) -> usize {
-        // NB: We cannot trust that `self.align` is a valid alignment because
+        // Alignment must be a power of two and less than or equal to
+        // `isize::MAX`.
+        //
+        // NB: We cannot assume that `self.align` is a valid alignment because
         // `libfuzzer` could have arbitrarily mutated its bytes.
         let align = self.align.checked_next_power_of_two().unwrap_or(1);
         align.min(MAX_ALIGN)
@@ -58,7 +61,10 @@ impl Layout {
     fn size(&self) -> usize {
         let align = self.align();
 
-        // NB: We cannot trust that `self.size` is a valid alignment because
+        // The size must not overflow `isize::MAX` when rounded up to our
+        // alignment.
+        //
+        // NB: We cannot assume that `self.size` is a valid alignment because
         // `libfuzzer` could have arbitrarily mutated its bytes.
         let size = if self
             .size

--- a/crates/fuzzing/src/lib.rs
+++ b/crates/fuzzing/src/lib.rs
@@ -14,11 +14,13 @@ use std::{collections::BTreeMap, mem, ptr::NonNull};
 // Note: it is easier to define our own layout type here than to reuse
 // `std::alloc::Layout` because we want to define a default mutator for `Layout`
 // but trait orphan rules make that impossible.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, bincode::Encode, bincode::Decode)]
 pub struct Layout {
     size: usize,
     align: usize,
 }
+
+const MAX_ALIGN: usize = 1 << 16;
 
 impl Default for Layout {
     fn default() -> Self {
@@ -46,9 +48,32 @@ impl Layout {
         }
     }
 
+    fn align(&self) -> usize {
+        let align = self.align.checked_next_power_of_two().unwrap_or(1);
+        align.min(MAX_ALIGN)
+    }
+
+    fn size(&self) -> usize {
+        let align = self.align();
+
+        if self
+            .size
+            .checked_next_multiple_of(align)
+            .is_some_and(|s| s < (isize::MAX as usize))
+        {
+            self.size
+        } else {
+            align
+        }
+    }
+
     fn alloc_layout(&self) -> std::alloc::Layout {
-        std::alloc::Layout::from_size_align(self.size, self.align)
-            .expect("should have a valid size and align")
+        let align = self.align();
+        let size = self.size();
+        match std::alloc::Layout::from_size_align(size, align) {
+            Ok(l) => l,
+            Err(e) => panic!("should be a valid layout: size={size}, align={align}; got {e}"),
+        }
     }
 }
 
@@ -101,9 +126,9 @@ impl Mutate<Layout> for LayoutMutator {
         // Mutate size.
         c.mutation(|ctx| {
             let max_size = if ctx.shrink() {
-                layout.size
+                layout.size()
             } else {
-                std::cmp::min(self.max_size, max_size_for_align(layout.align))
+                std::cmp::min(self.max_size, max_size_for_align(layout.align()))
             };
             layout.size = ctx.rng().gen_index(max_size + 1).unwrap();
             Ok(())
@@ -112,11 +137,11 @@ impl Mutate<Layout> for LayoutMutator {
         // Mutate alignment.
         c.mutation(|ctx| {
             let max_align_log2 = if ctx.shrink() {
-                layout.align.trailing_zeros() as usize
+                layout.align().trailing_zeros() as usize
             } else {
                 std::cmp::min(
                     self.max_align.trailing_zeros() as usize,
-                    max_align_for_size(layout.size).trailing_zeros() as usize,
+                    max_align_for_size(layout.size()).trailing_zeros() as usize,
                 )
             };
             let align_log2 = ctx.rng().gen_index(max_align_log2 + 1).unwrap();
@@ -138,7 +163,7 @@ impl Generate<Layout> for LayoutMutator {
 }
 
 /// A test operation.
-#[derive(Clone, Debug, Mutate)]
+#[derive(Clone, Debug, Mutate, bincode::Encode, bincode::Decode)]
 pub enum Op {
     Alloc { id: u32, layout: Layout },
     Dealloc { id: u32 },
@@ -203,6 +228,47 @@ impl Generate<Op> for OpMutator {
 #[derive(Clone, Debug, Default)]
 pub struct Ops {
     ops: Vec<Op>,
+}
+
+// Note: we use custom implementations of `Encode` and `Decode` so that we can
+// limit the size of `ops`; otherwise, `bincode` will attempt to allocate an
+// array of arbitrary length from the fuzzer-supplied data, which leads to OOMs.
+const MAX_OPS_TO_DECODE: usize = 1_000;
+impl<C> bincode::Decode<C> for Ops {
+    fn decode<D: bincode::de::Decoder<Context = C>>(
+        decoder: &mut D,
+    ) -> Result<Self, bincode::error::DecodeError> {
+        let len = u64::decode(decoder)?;
+        let len = usize::try_from(len)
+            .map_err(|e| bincode::error::DecodeError::OtherString(e.to_string()))?;
+        if len > MAX_OPS_TO_DECODE {
+            return Err(bincode::error::DecodeError::OtherString(format!(
+                "cannot decode an `Ops` of length {len}; max supported length is \
+                 {MAX_OPS_TO_DECODE}"
+            )));
+        }
+        let mut ops = Vec::with_capacity(len);
+        for _ in 0..len {
+            let op = Op::decode(decoder)?;
+            ops.push(op);
+        }
+        Ok(Ops { ops })
+    }
+}
+
+impl bincode::Encode for Ops {
+    fn encode<E: bincode::enc::Encoder>(
+        &self,
+        encoder: &mut E,
+    ) -> Result<(), bincode::error::EncodeError> {
+        let len = self.ops.len();
+        let len = u64::try_from(len).unwrap();
+        u64::encode(&len, encoder)?;
+        for op in &self.ops {
+            Op::encode(op, encoder)?;
+        }
+        Ok(())
+    }
 }
 
 impl DefaultMutate for Ops {
@@ -296,9 +362,11 @@ macro_rules! ensure {
     ( $cond:expr , $msg:expr $( , $args:expr )* $(,)? ) => {{
         let cond = $cond;
         if !cond {
+            let file = file!();
+            let line = line!();
             let msg = format!($msg $( , $args )* );
-            let str_cond = stringify!($cond);
-            return Err(format!("check failed: `{str_cond}`: {msg}"));
+            let cond = stringify!($cond);
+            return Err(format!("{file}:{line}: check failed: `{cond}`: {msg}"));
         }
     }};
 }
@@ -308,6 +376,13 @@ impl Ops {
     pub fn new(ops: impl IntoIterator<Item = Op>) -> Self {
         let ops = ops.into_iter().collect();
         Ops { ops }
+    }
+
+    /// Pop an operation off the end of this sequence. Returns whether an
+    /// operation was actually popped or not (i.e. whether this sequence was
+    /// non-empty before calling `pop`).
+    pub fn pop(&mut self) -> bool {
+        self.ops.pop().is_some()
     }
 
     /// Run these test operations with the given allocation limit.
@@ -333,6 +408,11 @@ impl Ops {
 
         // Fill an allocation with the given byte pattern.
         let fill = |ptr: NonNull<[u8]>, byte: u8| unsafe {
+            log::trace!(
+                "fill {:#p}..{:#p} with {byte:#0x}",
+                ptr.cast::<u8>(),
+                ptr.cast::<u8>().add(ptr.len())
+            );
             ptr.cast::<u8>().write_bytes(byte, ptr.len());
         };
 
@@ -351,25 +431,44 @@ impl Ops {
 
         // Assert that the given allocation is zeroed.
         let assert_zeroed = |ptr: NonNull<[u8]>| -> Result<(), String> {
-            let slice = unsafe { ptr.as_ref() };
-            ensure!(
-                slice.iter().all(|b| *b == 0),
-                "supposedly zeroed block of memory contains non-zero byte",
+            log::trace!(
+                "assert_zeroed(ptr = {ptr:#p}..{:#p} (len = {}))",
+                unsafe { ptr.cast::<u8>().add(ptr.len()) },
+                ptr.len()
             );
+            let slice = unsafe { ptr.as_ref() };
+            for b in slice {
+                ensure!(
+                    *b == 0,
+                    "supposedly zeroed block of memory contains non-zero byte {:#0x} at {:#p}",
+                    *b,
+                    b as *const _,
+                );
+            }
             Ok(())
         };
 
         // Assert that the given allocation satisfies its requested layout.
         let assert_fits_layout =
             |ptr: NonNull<[u8]>, layout: std::alloc::Layout| -> Result<(), String> {
-                ensure!(
-                    layout.size() <= ptr.len(),
-                    "actual allocated size is less than expected layout size",
+                log::trace!(
+                    "assert_fits_layout(ptr = {ptr:#p}..{:#p} (len = {}), layout = {layout:?})",
+                    unsafe { ptr.cast::<u8>().add(ptr.len()) },
+                    ptr.len()
                 );
+                let actual_size = ptr.len();
+                let expected_size = layout.size();
                 ensure!(
-                    layout.align().trailing_zeros()
-                        <= (ptr.cast::<u8>().as_ptr() as usize).trailing_zeros(),
-                    "actual allocated alignment is less than expected layout alignment",
+                    actual_size >= expected_size,
+                    "actual allocated size ({actual_size}) is less than expected layout size \
+                     ({expected_size})",
+                );
+                let actual_align = 1 << (ptr.cast::<u8>().as_ptr() as usize).trailing_zeros();
+                let expected_align = layout.align();
+                ensure!(
+                    actual_align >= expected_align,
+                    "actual allocated alignment ({actual_align}) is less than expected layout \
+                     alignment ({expected_align})",
                 );
                 Ok(())
             };
@@ -478,7 +577,7 @@ impl Ops {
 
             match op {
                 Op::Alloc { id, layout } => {
-                    if live.beyond_allocation_limit(layout.size) {
+                    if live.beyond_allocation_limit(layout.size()) {
                         continue;
                     }
 
@@ -502,7 +601,7 @@ impl Ops {
                 }
 
                 Op::AllocZeroed { id, layout } => {
-                    if live.beyond_allocation_limit(layout.size) {
+                    if live.beyond_allocation_limit(layout.size()) {
                         continue;
                     }
 
@@ -703,7 +802,9 @@ impl LiveMap {
 
     /// Would an allocation of the given size push us past our allocation limit?
     fn beyond_allocation_limit(&self, size: usize) -> bool {
-        self.total_allocated_bytes + size > self.allocation_limit
+        self.total_allocated_bytes
+            .checked_add(size)
+            .is_none_or(|n| n > self.allocation_limit)
     }
 
     /// Insert a new live allocation.

--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "deallocate-zeroed-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+bincode = { workspace = true }
+env_logger = { workspace = true }
+deallocate-zeroed-fuzzing = { path = "../crates/fuzzing" }
+libfuzzer-sys = "0.4"
+mutatis = { workspace = true }
+
+[[bin]]
+name = "ops"
+path = "fuzz_targets/ops.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/ops.rs
+++ b/fuzz/fuzz_targets/ops.rs
@@ -1,0 +1,63 @@
+#![no_main]
+
+use deallocate_zeroed_fuzzing::Ops;
+use libfuzzer_sys::{fuzz_mutator, fuzz_target, fuzzer_mutate};
+use mutatis::Session;
+
+const ALLOCATION_LIMIT: usize = 1 << 20; // 1MiB
+
+const fn bincode_config() -> impl bincode::config::Config {
+    bincode::config::standard()
+        .with_little_endian()
+        .with_fixed_int_encoding()
+}
+
+fuzz_mutator!(|data: &mut [u8], size: usize, max_size: usize, seed: u32| {
+    let _ = env_logger::try_init();
+
+    // With probability of about 1/8, just use the default mutator.
+    if seed.count_ones() % 8 == 0 {
+        return fuzzer_mutate(data, size, max_size);
+    }
+
+    // Decode the ops from the data, or use the default ops if that fails.
+    let mut ops = bincode::decode_from_slice::<Ops, _>(data, bincode_config())
+        .map_or_else(|_decode_err| Ops::default(), |(ops, _)| ops);
+
+    let mut session = Session::new().seed(seed.into()).shrink(max_size < size);
+
+    match session.mutate(&mut ops) {
+        Ok(()) => {
+            // Re-encode the mutated ops back into `data`.
+            loop {
+                if let Ok(new_size) = bincode::encode_into_slice(&ops, data, bincode_config()) {
+                    return new_size;
+                }
+
+                // When re-encoding fails (presumably because `data` is not
+                // large enough) then pop an op off the end and try again.
+                if ops.pop() {
+                    continue;
+                }
+
+                // But if we are out of ops to pop, then fall back to the
+                // default fuzzer mutation strategy.
+                break;
+            }
+        }
+        Err(_) => {}
+    }
+
+    // If we failed to mutate the ops for whatever reason, fall back to the
+    // fuzzer's default mutation strategies.
+    return fuzzer_mutate(data, size, max_size);
+});
+
+fuzz_target!(|data: &[u8]| {
+    let _ = env_logger::try_init();
+    if let Ok((ops, _)) = bincode::decode_from_slice::<Ops, _>(data, bincode_config()) {
+        if let Err(e) = ops.run(ALLOCATION_LIMIT) {
+            panic!("error: {e}");
+        }
+    }
+});

--- a/src/zero_aware_allocator.rs
+++ b/src/zero_aware_allocator.rs
@@ -32,7 +32,7 @@
 use core::ptr;
 
 use super::*;
-use metadata::{BlockInfo, FreeList};
+use metadata::{BlockInfo, FreeList, LiveSet};
 
 mod mutex;
 pub use mutex::{LockingMechanism, Mutex, MutexGuard, SingleThreadedLockingMechanism};
@@ -96,6 +96,37 @@ struct Zeroed {
     /// A fallback freelist for already-zeroed memory blocks that have alignment
     /// larger than we have an align-class for.
     very_large_aligns: FreeList,
+
+    /// The set of live allocations we've handed out to the user from one of our
+    /// free-lists.
+    ///
+    /// We maintain this set because the `Layout` that the block was originally
+    /// allocated from `inner` with is not necessarily the same `Layout` that
+    /// the user gave us when they asked for an already-zereod block of
+    /// memory. Consider the following sequence of events, for example:
+    ///
+    /// * `deallocate_zeroed(0x12345678, size = 64KiB)`
+    ///
+    ///   Now we have an already-zeroed entry for this allocation in one of our
+    ///   free-lists.
+    ///
+    /// * `allocate_zeroed(size = 62KiB) -> 0x12345678`
+    ///
+    ///   This new allocation's requested size isn't an exact match for our
+    ///   free-list entry, but is close enough that it is worth accepting a
+    ///   little bit of fragmentation slop rather than spending time zeroing
+    ///   62KiB of memory.
+    ///
+    /// * `grow(0x12345678, old_size=62KiB, new_size=...)`
+    ///
+    ///   When the user grows their allocation of "62KiB", we need to realize
+    ///   that it is actually 64KiB in size and act accordingly.
+    ///
+    /// It is critical that whenever we call into the `inner` allocator, we pass
+    /// the allocation's actual, original `Layout`. Passing the wrong layout is
+    /// a violation of the `Allocator` API's safety contract, so we could
+    /// trigger UB if we aren't careful here.
+    live_set: LiveSet,
 }
 
 impl<A, L> ZeroAwareAllocator<A, L>
@@ -110,6 +141,7 @@ where
         let zeroed = Zeroed {
             align_classes: [const { FreeList::new() }; NUM_ALIGN_CLASSES],
             very_large_aligns: FreeList::new(),
+            live_set: LiveSet::new(),
         };
         let zeroed = Mutex::new(zeroed, lock);
         ZeroAwareAllocator { inner, zeroed }
@@ -208,8 +240,11 @@ where
             // Start at the layout's align-class and try to find a suitably-sized
             // block for the layout, moving to larger and larger align-classes as
             // necessary.
-            let freelists = zeroed.align_classes[align_class..NUM_ALIGN_CLASSES]
-                .iter_mut()
+            let freelists = zeroed
+                .align_classes
+                .get_mut(align_class..NUM_ALIGN_CLASSES)
+                .into_iter()
+                .flat_map(|classes| classes.iter_mut())
                 .chain(Some(&mut zeroed.very_large_aligns));
 
             for freelist in freelists {
@@ -218,13 +253,16 @@ where
                 // allocator and return the block.
                 if let Some(node) = freelist.remove(&layout) {
                     let ret = node.non_null_slice_ptr();
-
-                    // Safety: the node was allocated from `self.inner`, is
-                    // currently allocated, and was removed from its freelist.
-                    unsafe {
-                        self.deallocate_block_info(node);
-                    }
-
+                    debug_assert!({
+                        let slice = unsafe {
+                            core::slice::from_raw_parts(
+                                node.ptr().as_ptr().cast_const(),
+                                node.layout().size(),
+                            )
+                        };
+                        slice.iter().all(|b| *b == 0)
+                    });
+                    zeroed.live_set.insert(node);
                     return Ok(ret);
                 }
             }
@@ -237,32 +275,124 @@ where
 
     #[inline]
     unsafe fn deallocate_already_zeroed(&self, ptr: NonNull<u8>, layout: Layout) {
+        debug_assert!({
+            let slice = core::slice::from_raw_parts(ptr.as_ptr().cast_const(), layout.size());
+            slice.iter().all(|b| *b == 0)
+        });
+
         if layout.size() == 0 {
             return;
         }
 
-        match self.allocate_block_info(ptr, layout) {
-            // If the inner allocator fails to allocate the node that we need
-            // for bookkeeping, then we can't keep track of this already-zeroed
-            // block, so simply eagerly return it to the inner allocator.
-            Err(_) => self.inner.deallocate(ptr, layout),
+        let mut zeroed = self.zeroed.lock();
+        let zeroed = &mut *zeroed;
+        let node = match zeroed.live_set.remove(&ptr) {
+            Some(node) => {
+                // The actual layout should imply the user layout.
+                debug_assert!(node.layout().size() >= layout.size());
+                debug_assert!(node.layout().align() >= layout.align());
+                // And any fragmentation we had accepted still be zeroed.
+                debug_assert!({
+                    let slice = core::slice::from_raw_parts(
+                        ptr.add(layout.size()).as_ptr().cast_const(),
+                        node.layout().size() - layout.size(),
+                    );
+                    slice.iter().all(|b| *b == 0)
+                });
+                node
+            }
+            None => match self.allocate_block_info(ptr, layout) {
+                Ok(node) => node,
+                // If the inner allocator fails to allocate the block info that
+                // we need for bookkeeping, then we can't keep track of this
+                // already-zeroed block, so simply eagerly return it to the
+                // inner allocator.
+                Err(_) => {
+                    self.inner.deallocate(ptr, layout);
+                    return;
+                }
+            },
+        };
 
-            Ok(node) => {
-                let mut zeroed = self.zeroed.lock();
-                let zeroed = &mut *zeroed;
+        // Get the appropriate freelist for this block's align-class.
+        let align_class = node.layout().align().ilog2() as usize;
+        let freelist = zeroed
+            .align_classes
+            .get_mut(align_class)
+            .unwrap_or_else(|| &mut zeroed.very_large_aligns);
 
-                // Get the appropriate freelist for this block's align-class.
-                let align_class = layout.align().ilog2() as usize;
-                let freelist = zeroed
-                    .align_classes
-                    .get_mut(align_class)
-                    .unwrap_or_else(|| &mut zeroed.very_large_aligns);
+        // Insert the block into its freelist.
+        freelist.insert(node);
+    }
 
-                // Insert the block into its freelist.
-                freelist.insert(node);
+    /// Before a `grow` or `grow_zeroed`, check whether we have the pointer in
+    /// our live-set. If it already satisfies the new size requirements, reuse
+    /// it. Otherwise, remove it from our live-set, as we will need to pass it
+    /// to the underlying allocator or re-allocate it.
+    unsafe fn pre_grow(
+        &self,
+        ptr: NonNull<u8>,
+        user_old_layout: Layout,
+        new_layout: Layout,
+    ) -> PreGrow {
+        let mut zeroed = self.zeroed.lock();
+        let zeroed = &mut *zeroed;
+
+        if let Some(node) = zeroed.live_set.find(&ptr) {
+            debug_assert_eq!(node.ptr(), ptr);
+            debug_assert!(node.layout().size() >= user_old_layout.size());
+            debug_assert!(node.layout().align() >= user_old_layout.align());
+
+            // If this is an allocation that was originally already zeroed,
+            // and its original inner layout can already satisfy this new
+            // layout, then we don't need to do anything further.
+            if node.layout().size() >= new_layout.size()
+                && node.layout().align() >= new_layout.align()
+            {
+                return PreGrow::Reuse {
+                    ptr: NonNull::slice_from_raw_parts(ptr, node.layout().size()),
+                    actual_layout: node.layout(),
+                };
+            }
+
+            let actual_old_layout = node.layout();
+
+            // We no longer need the live-set node. It is only required for
+            // when we are handing out already-zeroed blocks that we
+            // bookkeep internally and whose original layout might not match
+            // what the user thinks its layout is. From this point on, this
+            // allocation will either be fully managed by the inner
+            // allocator (in the case of a successful `grow`) or will be
+            // deallocated and replaced by a new already-zeroed allocation
+            // (in the case of growth failure). In either case, we no longer
+            // need a block-info node for this allocation.
+            zeroed
+                .live_set
+                .remove(node)
+                .expect("just found the node in the live-set, should still be there");
+            self.deallocate_block_info(node);
+
+            PreGrow::DoGrow { actual_old_layout }
+        } else {
+            // This is not an allocation we are managing: use the user's
+            // given old layout.
+            PreGrow::DoGrow {
+                actual_old_layout: user_old_layout,
             }
         }
     }
+}
+
+enum PreGrow {
+    /// The underlying inner allocation can be reused and does not need to be
+    /// resized.
+    Reuse {
+        ptr: NonNull<[u8]>,
+        actual_layout: Layout,
+    },
+    /// The underlying allocation cannot satisfy the growth request, we need to
+    /// actually grow or re-alloc.
+    DoGrow { actual_old_layout: Layout },
 }
 
 impl<A, L> Drop for ZeroAwareAllocator<A, L>
@@ -282,18 +412,49 @@ where
 {
     #[inline]
     fn allocate(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        if layout.size() == 0 {
+            let dangling = core::ptr::without_provenance::<u8>(layout.align());
+            let dangling = NonNull::new(dangling.cast_mut()).unwrap();
+            let dangling = NonNull::slice_from_raw_parts(dangling, 0);
+            return Ok(dangling);
+        }
+
         self.inner
             .allocate(layout)
             .or_else(|_| self.allocate_already_zeroed(layout))
     }
 
     #[inline]
-    unsafe fn deallocate(&self, ptr: NonNull<u8>, layout: Layout) {
-        self.inner.deallocate(ptr, layout);
+    unsafe fn deallocate(&self, ptr: NonNull<u8>, user_layout: Layout) {
+        if user_layout.size() == 0 {
+            debug_assert_eq!(
+                ptr.as_ptr().cast_const(),
+                core::ptr::without_provenance(user_layout.align())
+            );
+            return;
+        }
+
+        let mut zeroed = self.zeroed.lock();
+        let zeroed = &mut *zeroed;
+        let actual_layout = if let Some(node) = zeroed.live_set.remove(&ptr) {
+            let layout = node.layout();
+            self.deallocate_block_info(node);
+            layout
+        } else {
+            user_layout
+        };
+        self.inner.deallocate(ptr, actual_layout);
     }
 
     #[inline]
     fn allocate_zeroed(&self, layout: Layout) -> Result<NonNull<[u8]>, AllocError> {
+        if layout.size() == 0 {
+            let dangling = core::ptr::without_provenance::<u8>(layout.align());
+            let dangling = NonNull::new(dangling.cast_mut()).unwrap();
+            let dangling = NonNull::slice_from_raw_parts(dangling, 0);
+            return Ok(dangling);
+        }
+
         self.allocate_already_zeroed(layout)
             .or_else(|_| self.inner.allocate_zeroed(layout))
     }
@@ -302,28 +463,87 @@ where
     unsafe fn grow(
         &self,
         ptr: NonNull<u8>,
-        old_layout: Layout,
+        user_old_layout: Layout,
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, AllocError> {
-        self.inner.grow(ptr, old_layout, new_layout).or_else(|_| {
-            let new = self.allocate_already_zeroed(new_layout)?;
-            ptr::copy_nonoverlapping(
+        if user_old_layout.size() == 0 {
+            debug_assert_eq!(
                 ptr.as_ptr().cast_const(),
-                new.cast().as_ptr(),
-                old_layout.size(),
+                core::ptr::without_provenance(user_old_layout.align())
             );
-            Ok(new)
-        })
+            return self.allocate(new_layout);
+        }
+
+        let actual_old_layout = match self.pre_grow(ptr, user_old_layout, new_layout) {
+            PreGrow::Reuse {
+                ptr,
+                actual_layout: _,
+            } => return Ok(ptr),
+            PreGrow::DoGrow { actual_old_layout } => actual_old_layout,
+        };
+
+        match self.inner.grow(ptr, actual_old_layout, new_layout) {
+            Ok(ptr) => Ok(ptr),
+
+            // If the inner allocator cannot grow this allocation, see if we
+            // have an already-zeroed block that will work.
+            Err(_) => {
+                let new_ptr = self.allocate_already_zeroed(new_layout)?;
+                debug_assert_ne!(new_ptr.cast::<u8>(), ptr);
+
+                // Copy over the bytes from the old allocation to the new one.
+                ptr::copy_nonoverlapping(
+                    ptr.as_ptr().cast_const(),
+                    new_ptr.cast::<u8>().as_ptr(),
+                    // NB: we only need to copy the user's bytes, not the actual
+                    // inner allocation's bytes.
+                    user_old_layout.size(),
+                );
+
+                // The contract is that when `grow` succeeds, it takes ownership
+                // of the old pointer, so we must deallocate the old allocation.
+                self.inner.deallocate(ptr, actual_old_layout);
+
+                Ok(new_ptr)
+            }
+        }
     }
 
     #[inline]
     unsafe fn grow_zeroed(
         &self,
         ptr: NonNull<u8>,
-        old_layout: Layout,
+        user_old_layout: Layout,
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, AllocError> {
-        let bytes_to_zero = new_layout.size() - old_layout.size();
+        if user_old_layout.size() == 0 {
+            debug_assert_eq!(
+                ptr.as_ptr().cast_const(),
+                core::ptr::without_provenance(user_old_layout.align())
+            );
+            return self.allocate_zeroed(new_layout);
+        }
+
+        let actual_old_layout = match self.pre_grow(ptr, user_old_layout, new_layout) {
+            PreGrow::Reuse { ptr, actual_layout } => {
+                // NB: we cannot assume that the fragmentation slop (if any) is
+                // still zeroed, because we give out the whole block as a
+                // `NonNull<[u8]>` slice to the user. Therefore, we have to
+                // manually zero here.
+                let slop = ptr.cast::<u8>().add(user_old_layout.size());
+                let slop_len = actual_layout.size() - user_old_layout.size();
+                slop.write_bytes(0, slop_len);
+                return Ok(ptr);
+            }
+            PreGrow::DoGrow { actual_old_layout } => actual_old_layout,
+        };
+
+        // NB: we could have enough capacity in the existing allocation, but
+        // cannot reuse the allocation because it has the wrong alignment.
+        // Therefore, it is not necessarily the case that the old layout is
+        // smaller than the new layout and so we do a saturating subtraction
+        // here.
+        let bytes_to_zero = new_layout.size().saturating_sub(actual_old_layout.size());
         let bytes_to_copy = new_layout.size() - bytes_to_zero;
 
         // We can't split or grow blocks in place so if we don't want to use the
@@ -333,7 +553,7 @@ where
         // old allocation could be grown in place) then just defer to the
         // underlying allocator.
         if bytes_to_copy > 2usize.saturating_mul(bytes_to_zero) {
-            if let Ok(p) = self.inner.grow_zeroed(ptr, old_layout, new_layout) {
+            if let Ok(p) = self.inner.grow_zeroed(ptr, user_old_layout, new_layout) {
                 return Ok(p);
             }
         }
@@ -342,7 +562,7 @@ where
         ptr::copy_nonoverlapping(
             ptr.as_ptr().cast_const(),
             new.cast().as_ptr(),
-            old_layout.size(),
+            user_old_layout.size(),
         );
         Ok(new)
     }
@@ -354,8 +574,35 @@ where
         old_layout: Layout,
         new_layout: Layout,
     ) -> Result<NonNull<[u8]>, AllocError> {
+        if old_layout.size() == 0 {
+            debug_assert_eq!(
+                ptr.as_ptr().cast_const(),
+                core::ptr::without_provenance(old_layout.align())
+            );
+            let dangling = core::ptr::without_provenance::<u8>(new_layout.align());
+            let dangling = NonNull::new(dangling.cast_mut()).unwrap();
+            let dangling = NonNull::slice_from_raw_parts(dangling, 0);
+            return Ok(dangling);
+        }
+
         // We can't split allocations ourselves, so just defer to the inner
         // allocator.
+
+        let mut zeroed = self.zeroed.lock();
+        let zeroed = &mut *zeroed;
+
+        // Make sure that we are passing the original, underlying `Layout` to
+        // the inner allocator. After shrinking, this pointer will no longer
+        // managed by us, so remove and deallocate its block-info node from the
+        // live-set (if any).
+        let old_layout = if let Some(node) = zeroed.live_set.remove(&ptr) {
+            let actual_old_layout = node.layout();
+            self.deallocate_block_info(node);
+            actual_old_layout
+        } else {
+            old_layout
+        };
+
         self.inner.shrink(ptr, old_layout, new_layout)
     }
 }
@@ -365,8 +612,16 @@ where
     A: Allocator,
     L: LockingMechanism,
 {
-    unsafe fn deallocate_zeroed(&self, pointer: NonNull<u8>, layout: Layout) {
-        self.deallocate_already_zeroed(pointer, layout);
+    unsafe fn deallocate_zeroed(&self, ptr: NonNull<u8>, layout: Layout) {
+        if layout.size() == 0 {
+            debug_assert_eq!(
+                ptr.as_ptr().cast_const(),
+                core::ptr::without_provenance(layout.align())
+            );
+            return;
+        }
+
+        self.deallocate_already_zeroed(ptr, layout);
     }
 }
 
@@ -425,10 +680,13 @@ mod metadata {
         }
     }
 
+    pub(super) struct ByAlignClass;
+    pub(super) type FreeList = SplayTree<'static, ByAlignClass>;
+
     /// Comparison between two `BlockInfo`s.
     ///
     /// This is used for ordering blocks within a tree.
-    impl<'a> TreeOrd<'a, BlockInfo<'a>> for BlockInfo<'a> {
+    impl<'a> TreeOrd<'a, ByAlignClass> for BlockInfo<'a> {
         fn tree_cmp(&self, other: &'a BlockInfo<'a>) -> Ordering {
             // Compare first by size, since that is the first hard constraint we
             // must satisfy and property we query for.
@@ -455,7 +713,7 @@ mod metadata {
     ///
     /// This is used when searching for a block to satisfy a requested
     /// allocation.
-    impl<'a> TreeOrd<'a, BlockInfo<'a>> for Layout {
+    impl<'a> TreeOrd<'a, ByAlignClass> for Layout {
         fn tree_cmp(&self, block: &'a BlockInfo<'a>) -> Ordering {
             // Compare sizes. Allow for some fragmentation, but not too much,
             // because we can't split blocks ourselves. See the doc comment for
@@ -486,11 +744,37 @@ mod metadata {
     }
 
     intrusive_splay_tree::impl_intrusive_node! {
-        impl<'a> IntrusiveNode<'a> for BlockInfo<'a>
+        impl<'a> IntrusiveNode<'a> for ByAlignClass
         where
             type Elem = BlockInfo<'a>,
             node = node;
     }
 
-    pub(super) type FreeList = SplayTree<'static, BlockInfo<'static>>;
+    pub(super) struct ByPointer;
+    pub(super) type LiveSet = SplayTree<'static, ByPointer>;
+
+    /// Comparison between two `BlockInfo`s by pointer.
+    ///
+    /// This is used for ordering blocks within a tree.
+    impl<'a> TreeOrd<'a, ByPointer> for BlockInfo<'a> {
+        fn tree_cmp(&self, other: &'a BlockInfo<'a>) -> Ordering {
+            Ord::cmp(&self.ptr, &other.ptr)
+        }
+    }
+
+    /// Comparison between a pointer and a `BlockInfo`.
+    ///
+    /// Used when searching the live-set for a particular allocation.
+    impl<'a> TreeOrd<'a, ByPointer> for NonNull<u8> {
+        fn tree_cmp(&self, other: &'a BlockInfo<'a>) -> Ordering {
+            Ord::cmp(self, &other.ptr)
+        }
+    }
+
+    intrusive_splay_tree::impl_intrusive_node! {
+        impl<'a> IntrusiveNode<'a> for ByPointer
+        where
+            type Elem = BlockInfo<'a>,
+            node = node;
+    }
 }


### PR DESCRIPTION
This fixes a bug where we could accidentally pass the wrong `Layout` to the
underlying allocator when growing or shrinking an allocation. When we have an
already-zeroed block of size N, we can satisfy allocations of size `M` where `M
< N` if we are willing to accept some fragmentation slop. We currently do this
but only when the slop is relatively small (1/8 the size of the allocation or
less). If we handed out such an allocation, and then the user wants to grow or
shrink it, then we would pass the user's layout to the underlying allocator,
rather than the original layout. Passing the wrong layout to an allocator is a
violation of the `Allocator` interface's safety contract, and could therefore
lead to UB. In fact, this was leading to assertion failures when paired with
`dlmalloc`.

This commit also sets up and enables fuzzing via libfuzzer with our existing
mutator and oracle; previously we were only using the mutator and oracle for
property-testing style tests. I forgot to do this originally and just stopped
after I had the property-tests working with the mutator and oracle.